### PR TITLE
[XCPNG-2798] Add config file for emulex-lpfc-alt.

### DIFF
--- a/emulex-lpfc-alt-8.3.cfg
+++ b/emulex-lpfc-alt-8.3.cfg
@@ -1,0 +1,6 @@
+PACK_DESC="Driver Pack for Emulex lpfc device driver"
+PACK_UUID="bd4fd881-4c41-4c15-a7e3-e8a43a7039cf"
+PACK_BUILD="pack.0.1"
+RPM_FILE="emulex-lpfc-alt-14.4.393.31-1.1.xcpng8.3.x86_64.rpm"
+RPM_SHA256="52e0e18287d70754d0d1a914a7659b039a80687436306fcddad8e41d28900c71"
+GPG_PUBKEY_FILE="RPM-GPG-KEY-XCP-SingleUse"


### PR DESCRIPTION
https://project.vates.tech/vates-global/browse/XCPNG-2798/

Testing:
 - Used the built RPMs from https://koji.xcp-ng.org/buildinfo?buildID=5194 (https://project.vates.tech/vates-global/browse/XCPNG-3000)
 - Built the ISO using the above RPMs locally